### PR TITLE
Fixes the thumbnail loading for animated stickers and emojis.

### DIFF
--- a/telethon/client/downloads.py
+++ b/telethon/client/downloads.py
@@ -768,7 +768,8 @@ class DownloadMethods:
             # :tl:`PhotoPathSize` is used for animated stickers preview, and the thumb is actually
             # a SVG path of the outline. Users expect thumbnails to be JPEG files, so pretend this
             # thumb size doesn't actually exist (#1655).
-            if isinstance(thumbs[i], types.PhotoPathSize):
+            # The same applies to the :tl:`VideoSizeEmojiMarkup` and :tl:`VideoSizeStickerMarkup`
+            if isinstance(thumbs[i], (types.PhotoPathSize, types.VideoSizeEmojiMarkup, types.VideoSizeStickerMarkup)):
                 thumbs.pop(i)
 
         if thumb is None:


### PR DESCRIPTION
An error occurs during the channel thumbnail loading if an animated sticker or emoji is set as the cover:
```
Traceback (most recent call last):
  File "/app/telegram/channels.py", line 145, in get_channel_photo
    local_file = await client.download_profile_photo(chat, '/tmp/%s' % hash, download_big=is_large)
  File "/usr/local/lib/python3.7/site-packages/telethon/client/downloads.py", line 265, in download_profile_photo
    thumb=thumb, progress_callback=None
  File "/usr/local/lib/python3.7/site-packages/telethon/client/downloads.py", line 832, in _download_photo
    file_size = size.size
AttributeError: 'VideoSizeStickerMarkup' object has no attribute 'size'
```
These types should be ignored during the thumbnail search.